### PR TITLE
Added support for Vaadin Framework 7 and 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ One of the key differences from the traditional `cyclonedx-maven-plugin`/`depend
 
 Even though this plug-in is not bound by default to any of the life-cycle stages, it requires the projects to be built before running:
 
-`mvn package com.vaadin.dtrack:dtrack-maven-plugin:2.0.0:upload`
+`mvn package com.vaadin.dtrack:dtrack-maven-plugin:2.0.1:upload`
 
 Alternatively, you can add plug-in to your `pom.xml`:
 
@@ -19,7 +19,7 @@ Alternatively, you can add plug-in to your `pom.xml`:
 <plugin>
     <groupId>com.vaadin.dtrack</groupId>
     <artifactId>dtrack-maven-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 </plugin>
 ...
 ```
@@ -127,9 +127,9 @@ npmDependencies:
 ```xml
 ...
 <plugin>
-    <groupId>com.github.fluorumlabs</groupId>
+    <groupId>com.vaadin.dtrack</groupId>
     <artifactId>dtrack-maven-plugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <configuration>
         <settings>
             <!--

--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,14 @@
     <groupId>com.vaadin.dtrack</groupId>
     <artifactId>dtrack-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>17</java.version>
+        <java.version>8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <maven.version>3.9.9</maven.version>
+        <maven.version>3.9.0</maven.version>
     </properties>
 
     <dependencyManagement>
@@ -163,11 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>17</source>
-                    <target>17</target>
-                </configuration>
+                <version>3.14.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <java.version>8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <maven.version>3.9.0</maven.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/com/github/fluorumlabs/dtrackmavenplugin/DtrackGenerateMojo.java
+++ b/src/main/java/com/github/fluorumlabs/dtrackmavenplugin/DtrackGenerateMojo.java
@@ -206,6 +206,11 @@ public class DtrackGenerateMojo extends AbstractMojo {
             return true;
         }
         for (MavenProject mavenProject : parents) {
+            //skip if no local pom exists
+            if(mavenProject.getOriginalModel().getPomFile() == null){
+                return true;
+            }
+
             // Skip if current project directory (or one of the parents) contains
             // .dtrackignore file
             if (Files.exists(mavenProject.getOriginalModel().getPomFile().toPath().getParent().resolve(".dtrackignore"))) {

--- a/src/main/java/com/github/fluorumlabs/dtrackmavenplugin/DtrackUploadMojo.java
+++ b/src/main/java/com/github/fluorumlabs/dtrackmavenplugin/DtrackUploadMojo.java
@@ -16,7 +16,9 @@
 
  package com.github.fluorumlabs.dtrackmavenplugin;
 
- import org.apache.maven.plugin.MojoFailureException;
+ import java.util.List;
+
+import org.apache.maven.plugin.MojoFailureException;
  import org.apache.maven.plugins.annotations.Mojo;
  import org.apache.maven.plugins.annotations.ResolutionScope;
  
@@ -66,7 +68,7 @@
          Semver newVersion = new Semver(getProject().getVersion(), Semver.SemverType.LOOSE);
  
          try {
-             var otherProjects = projectApi.getProjects(null, "1000", "0", "1000", null, null, getConfiguration().getProjectName(), Boolean.TRUE, null, null);
+             List<Project> otherProjects = projectApi.getProjects(null, "1000", "0", "1000", null, null, getConfiguration().getProjectName(), Boolean.TRUE, null, null);
              for (Project otherProject : otherProjects) {
                  Semver otherVersion = new Semver(otherProject.getVersion(), Semver.SemverType.LOOSE);
  

--- a/src/main/java/com/github/fluorumlabs/dtrackmavenplugin/engine/BomReactor.java
+++ b/src/main/java/com/github/fluorumlabs/dtrackmavenplugin/engine/BomReactor.java
@@ -307,7 +307,7 @@ public class BomReactor {
         String bomJson = bomGenerator.toJsonString();
         String version = bom.getMetadata().getComponent().getVersion();
 
-        bomApi.uploadBom(null, null, projectName, version, null, null, null, null, null, bomJson);
+        bomApi.uploadBom(null, Boolean.TRUE, projectName, version, null, null, null, null, null, bomJson);
     }
 
     public void write(Path target, String groupId, String artifactId, String version) throws ApiException {
@@ -433,7 +433,7 @@ public class BomReactor {
     private MavenProject readPom(InputStream input) {
         try {
             MavenXpp3Reader mavenreader = new MavenXpp3Reader();
-            try (var reader = new XmlStreamReader(input)) {
+            try (XmlStreamReader reader = new XmlStreamReader(input)) {
                 Model model = mavenreader.read(reader);
                 return new MavenProject(model);
             }


### PR DESCRIPTION
- Plugin Java version changed to 8 to fully support Framework 7/8
- Fixed a problem with missing local POMs for Framework 7/8
- New projects inside the platform will now automatically be added to dtrack
- Version bumped to 2.0.1
- Updated documentation